### PR TITLE
Updated Readme file 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-ARDUINOSW_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-TOOLCHAIN_URL := https://downloadmirror.intel.com/25470/eng/arc-toolchain-linux64-arcem-1.0.1.tar.bz2
-TOOLCHAIN     := $(notdir $(TOOLCHAIN_URL))
-CORELIBS_URL  ?= https://github.com/01org/corelibs-arduino101/archive/master.zip
-CORELIBS_ZIP  := $(notdir $(CORELIBS_URL))
-ARDUINO_URL   := https://github.com/arduino/Arduino/archive/1.6.9.zip
-ARDUINO_ZIP   := $(notdir $(ARDUINO_URL))
+ARDUINOSW_DIR  := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+TOOLCHAIN_URL  := https://downloadmirror.intel.com/25470/eng/arc-toolchain-linux64-arcem-1.0.1.tar.bz2
+TOOLCHAIN      := $(notdir $(TOOLCHAIN_URL))
+CORELIBS_URL   := https://github.com/01org/corelibs-arduino101/archive/master.zip
+CORELIBS_ZIP   := $(notdir $(CORELIBS_URL))
+ARDUINO_URL    := https://github.com/arduino/Arduino/archive/1.6.9.zip
+ARDUINO_ZIP    := $(notdir $(ARDUINO_URL))
 
 help:
 
@@ -44,3 +44,7 @@ arduino-ide:
 	mv Arduino-* arduino-ide
 	rm /tmp/$(ARDUINO_ZIP)
 
+install-grove:
+	@echo "Installing Grove Starter Kit Sketchbook"
+	git clone https://github.com/vraoresearch/Curie_ODK_Grove_sketchbook.git $(ARDUINOSW_DIR)/examples/grove
+	mv $(ARDUINOSW_DIR)examples/grove/libraries/*  $(ARDUINOSW_DIR)libraries/

--- a/README.md
+++ b/README.md
@@ -16,3 +16,44 @@ Make sure `CODK_DIR` variable is set to the CODK top-level path
   $ make compile
   $ make upload SERIAL_PORT=/dev/ttyACM0
 ```
+
+If your sketch has dependencies, you must include it's path
+in the makefile using the `LIBDIR =` variable.
+
+Arduino Built-in Libraries are located at:
+
+`$(ARDUINOIDE_DIR)/libraries/`
+For example you can include the WIFi library as follows:
+
+`LIBDIR = $(ARDUINOIDE_DIR)/libraries/WiFi/src `
+
+All Curie versions of the Arduino Built-in Libraries, and Curie specific 
+Libraries are located at:
+
+`$(ARDUINOSW_DIR)/corelibs/libraries/ `
+
+The following Libraries are available:
+
++ CurieBLE
++ CurieEEPROM
++ CurieIMU
++ CurieMailbox
++ CurieSMC
++ CurieSoftwareSerial
++ CurieTime
++ SerialFLash
++ Servo
++ SPI
++ Wire
+
+For example you can include the WIFi library as follows:
+
+`LIBDIR = $(ARDUINOSW_DIR)/corelibs/libraries/Wire/src `
+	
+The folder for User and External Libraries is referenced as follows:
+
+`$(ARDUINOSW_DIR)/libraries/ `
+
+For example you can include your library library as follows:
+
+`LIBDIR = $(ARDUINOSW_DIR)/libraries/<Your_Library>/src `

--- a/libraries/README
+++ b/libraries/README
@@ -1,1 +1,5 @@
 Place Arduino libraries for sketches in this folder.
+Make sure to include your library library in your application makefile as follows:
+
+`LIBDIR = $(ARDUINOSW_DIR)/libraries/<Your_Library>/src `
+


### PR DESCRIPTION
1. Updated Readme file 
Made changes to:
Readme.md
To show how to include sketch dependencies in application makefile for Curie libraries and user libraries
Made changes to"
/library/Readme.md
To show how to include path in application makefile
This is independent of #2 below:

2. Grove Install Commit
Updated Makefile with new option to install Grove Starter Kit Sketchbook adapted for convert-sketch
The source for adapted Grove Starter Kit Sketchbook with appropriate makefiles is available at
https://github.com/vraoresearch/Curie_ODK_Grove_sketchbook.git

Usage:
In the CODK_DIR
```
cd arc
make install-grove
```
Repo for Sketchbook can be transferred to 01.org
