### PR TITLE
Add library dependency info to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,44 @@ Make sure `CODK_DIR` variable is set to the CODK top-level path
   $ make compile
   $ make upload SERIAL_PORT=/dev/ttyACM0
 ```
+
+If your sketch has dependencies, you must include it's path
+in the makefile using the `LIBDIR =` variable.
+
+Arduino Built-in Libraries are located at:
+
+`$(ARDUINOIDE_DIR)/libraries/`
+For example you can include the Wi-Fi library as follows:
+
+`LIBDIR = $(ARDUINOIDE_DIR)/libraries/WiFi/src `
+
+All Curie versions of the Arduino Built-in Libraries, and Curie specific 
+Libraries are located at:
+
+`$(ARDUINOSW_DIR)/corelibs/libraries/ `
+
+The following Libraries are available:
+
++ CurieBLE
++ CurieEEPROM
++ CurieIMU
++ CurieMailbox
++ CurieSMC
++ CurieSoftwareSerial
++ CurieTime
++ SerialFLash
++ Servo
++ SPI
++ Wire
+
+For example you can include the Wire library as follows:
+
+`LIBDIR = $(ARDUINOSW_DIR)/corelibs/libraries/Wire/src `
+	
+The folder for User and External Libraries is referenced as follows:
+
+`$(ARDUINOSW_DIR)/libraries/ `
+
+For example you can include your library library as follows:
+
+`LIBDIR = $(ARDUINOSW_DIR)/libraries/<Your_Library>/src `

--- a/libraries/README
+++ b/libraries/README
@@ -1,1 +1,4 @@
 Place Arduino libraries for sketches in this folder.
+Make sure to include your library library in your application makefile as follows:
+
+`LIBDIR = $(ARDUINOSW_DIR)/libraries/<Your_Library>/src `


### PR DESCRIPTION
Explain to users that they must add external library
paths to LIBDIRS variable for successful compilation.