### PR TITLE
Re-enable the unstripped elf saving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ corelibs:
 	unzip /tmp/$(CORELIBS_ZIP) -d $(ARDUINOSW_DIR)
 	mv $(ARDUINOSW_DIR)/corelibs-* $(ARDUINOSW_DIR)/corelibs
 	rm /tmp/$(CORELIBS_ZIP)
-
+	sed '/#recipe.hooks.objcopy.preobjcopy.1.pattern/s/^#//g' $(ARDUINOSW_DIR)/platform.txt
 
 arc32:
 	@echo "Downloading ARC Toolchain"


### PR DESCRIPTION
Debug elf saving was disabled in order to make IDE more fool proof: https://github.com/01org/corelibs-arduino101/pull/314
This commit re-enables the elf saving so that it'll work on make debug-* targets.