### PR TITLE
convert-sketch: strip "#line" lines from converted sketch

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -158,6 +158,7 @@ convert-sketch:
 	-prefs=build.warn_data_percentage=75 \
 	"$(SKETCH)"  
 	cp $(current_dir)/tmp/sketch/$(SKETCH).cpp $(current_dir)
+	sed -i 's/^#line [0-9]*.*$$//g' $(current_dir)/$(SKETCH).cpp
 
 clean-all: clean
 	@echo Removing $(CORE_OBJS) $(CORE_A) $(CORELIBS_DIR)/cores/arduino/core.a


### PR DESCRIPTION
These lines are added by the Arduino builder to ensure that line numbers
in error messages will match line numbers in the sketch. We don't need
them, but GDB doesn't like these lines, and debugging a file that
contains them doesn't seem to work so well. Stripping them out after
conversion seems the best option

@calvinatintel please test